### PR TITLE
Fixed Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "longjohn": "^0.2.11",
     "moment": "^2.17.1",
     "moment-duration-format": "^1.3.0",
-    "sylphy": "github:pyraxo/sylphy#dev",
+    "sylphy": "github:pyraxo/sylphy",
     "winston": "^2.3.0",
     "winston-daily-rotate-file": "^1.4.2"
   }


### PR DESCRIPTION
Package dependencies required a dev branch of sylphy, which no longer exists. Fixed to use the master branch instead.